### PR TITLE
Bump minimum swift tools version to 5.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "*"
+  workflow_dispatch:
+
+jobs:
+  macos-test:
+    runs-on: macos-14
+    environment: default
+    strategy:
+      matrix:
+        xcode: ["16.0"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Select Xcode ${{ matrix.xcode }}
+        run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
+      - name: Build package
+        run: xcodebuild -scheme blackberry-dynamics-ios-sdk-Package -destination generic/platform=iOS

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.7
 
 import PackageDescription
 


### PR DESCRIPTION
bugfix/swift-tools-version-does-not-support-minimum-iOS-version-of-16